### PR TITLE
Start service asynchronously

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1171,11 +1171,9 @@ version = "1.0.3"
 
 [[deps.JobSchedulers]]
 deps = ["Dates", "JLD2", "JSON", "Logging", "OrderedCollections", "Pipelines", "PrettyTables", "Printf", "Reexport", "Term", "Terming", "Test"]
-git-tree-sha1 = "c1424b00ea1d37df3bfe87c2e4ad16b28be671da"
-repo-rev = "feat/accept-interrupt"
-repo-url = "https://github.com/fivegrant/JobSchedulers.jl"
+git-tree-sha1 = "568c4fe4c1ae76ada68604c9a1ea6f76e6030104"
 uuid = "eeff360b-c02d-44d3-ab26-4013c616a17e"
-version = "0.7.12"
+version = "0.8.1"
 
 [[deps.JpegTurbo_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]

--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ With docker compose:
 ```
 docker compose --file docker/docker-compose.yml up --build
 ```
+
+With Julia REPL:
+
+```
+julia> using SimulationService
+julia> start!()
+julia> # output of REST API and Scheduler
+julia> stop!()
+julia> # you may safely leave the repl or rerun `start!`
+````

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -13,4 +13,4 @@ RUN julia -e 'using Pkg; Pkg.resolve();'
 
 # Launch simulation-service
 EXPOSE 8080
-CMD [ "julia", "--threads",  "4", "-e", "using SimulationService; SimulationService.start!();" ]
+CMD [ "julia", "--threads",  "4", "-e", "using SimulationService; SimulationService.start!(); while true sleep(10000) end" ]

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -13,4 +13,4 @@ RUN julia -e 'using Pkg; Pkg.resolve();'
 
 # Launch simulation-service
 EXPOSE 8080
-CMD [ "julia", "--threads",  "4", "-e", "using SimulationService; SimulationService.run!();" ]
+CMD [ "julia", "--threads",  "4", "-e", "using SimulationService; SimulationService.start!();" ]


### PR DESCRIPTION
Changes:
- Replace `run!` with non-blocking `start!`
- Add terminating function `stop!`
- Switch back to upstream JobSchedulers.jl
- (side effect) Configure scheduler before starting it
- Include REPL usage for Simulation Service in README