### PR TITLE
Remove discontinuity handling in the callback

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimulationService"
 uuid = "e66378d9-a322-4933-8764-0ce0bcab4993"
 authors = ["Five Grant <5@fivegrant.com>"]
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 AMQPClient = "79c8b4cd-a41a-55fa-907c-fab5288e1383"

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -98,9 +98,11 @@ function (o::IntermediateResults)(integrator)
         publish_to_rabbitmq(; iter=iter, time=t, params=u, abserr=norm(u - uprev), id=o.id,
             retcode=SciMLBase.check_error(integrator))
     end
+    EasyModelAnalysis.DifferentialEquations.u_modified!(integrator, false)
 end
 
-get_callback(o::OperationRequest) = DiscreteCallback((args...) -> true, IntermediateResults(o.id))
+get_callback(o::OperationRequest) = DiscreteCallback((args...) -> true, IntermediateResults(o.id), 
+                                                      save_positions = (false,false))
 
 
 #----------------------------------------------------------------------# dataframe_with_observables


### PR DESCRIPTION
since it's just for monitoring, we should disable the extra saving that is occurring with it. By default it does a pre and post save at the callback points in the assumption that it's required for accurately handling the resolution of the discontinuity. But here we don't want that.