### PR TITLE
attempt to fix precompile issues when running container

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -5,6 +5,7 @@ WORKDIR /simulation-service
 COPY Project.toml /simulation-service/
 COPY Manifest.toml /simulation-service/
 COPY src/ /simulation-service/src/
+COPY examples/ /simulation-service/examples/
 ENV JULIA_PROJECT=.
 RUN julia -e 'using Pkg; Pkg.instantiate();'
 


### PR DESCRIPTION
Attempt to address the error below when starting via the docker-image. The docker file missing examples directory seems to be the culprit - note I didn't test this, trying to build the image brought my system to its knees.

```
WARNING: Method definition istaskfailed(Task) in module Base at task.jl:251 overwritten in module JobSchedulers at /root/.julia/packages/JobSchedulers/5Qozb/src/scheduler.jl:68.
  ** incremental compilation may be fatally broken for this module **

WARNING: both SciMLBase and BlackBoxOptim export "OptimizationProblem"; uses of it in module OptimizationBBO must be qualified
WARNING: both Plots and LinearAlgebra export "rotate!"; uses of it in module EasyModelAnalysis must be qualified
WARNING: both Bijectors and Base export "stack"; uses of it in module Turing must be qualified
ERROR: LoadError: ArgumentError: invalid JSON at byte position 1 while parsing type Any: InvalidChar
/simulation-service/src/..

Stacktrace:
  [1] invalid(error::JSON3.Error, buf::Base.CodeUnits{UInt8, String}, pos::Int64, T::Type)
    @ JSON3 ~/.julia/packages/JSON3/jTUC3/src/JSON3.jl:30
  [2] read!(buf::Base.CodeUnits{UInt8, String}, pos::Int64, len::Int64, b::UInt8, tape::Vector{UInt64}, tapeidx::Int64, ::Type{Any}, checkint::Bool; allow_inf::Bool)
    @ JSON3 ~/.julia/packages/JSON3/jTUC3/src/read.jl:139
  [3] read!
    @ ~/.julia/packages/JSON3/jTUC3/src/read.jl:87 [inlined]
  [4] read(json::String; jsonlines::Bool, numbertype::Nothing, kw::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ JSON3 ~/.julia/packages/JSON3/jTUC3/src/read.jl:57
  [5] read
    @ ~/.julia/packages/JSON3/jTUC3/src/read.jl:30 [inlined]
  [6] macro expansion
    @ /simulation-service/src/precompile.jl:2 [inlined]
  [7] top-level scope
    @ ~/.julia/packages/PrecompileTools/0yi7r/src/workloads.jl:74
  [8] include(mod::Module, _path::String)
    @ Base ./Base.jl:457
  [9] include(x::String)
    @ SimulationService /simulation-service/src/SimulationService.jl:1
 [10] top-level scope
    @ /simulation-service/src/SimulationService.jl:436
 [11] include
    @ ./Base.jl:457 [inlined]
 [12] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
    @ Base ./loading.jl:2049
 [13] top-level scope
    @ stdin:3
in expression starting at /simulation-service/src/precompile.jl:1
in expression starting at /simulation-service/src/SimulationService.jl:1
in expression starting at stdin:3
ERROR: Failed to precompile SimulationService [e66378d9-a322-4933-8764-0ce0bcab4993] to "/root/.julia/compiled/v1.9/SimulationService/jl_FUwwuz".
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] compilecache(pkg::Base.PkgId, path::String, internal_stderr::IO, internal_stdout::IO, keep_loaded_modules::Bool)
   @ Base ./loading.jl:2300
 [3] compilecache
   @ ./loading.jl:2167 [inlined]
 [4] _require(pkg::Base.PkgId, env::String)
   @ Base ./loading.jl:1805
 [5] _require_prelocked(uuidkey::Base.PkgId, env::String)
   @ Base ./loading.jl:1660
 [6] macro expansion
   @ ./loading.jl:1648 [inlined]
 [7] macro expansion
   @ ./lock.jl:267 [inlined]
 [8] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:1611
```